### PR TITLE
Fix responsive layout: mobile grid and hamburger navbar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,25 +1,62 @@
+import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import logo from "../assets/logo.svg";
 
 function Navbar() {
   const { pathname } = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const linkClass = (path) =>
+    pathname === path || (path !== "/" && pathname.startsWith(path))
+      ? "text-pink-600 underline"
+      : "text-gray-700 hover:text-pink-500 transition";
+
   return (
     <nav className="w-full px-8 py-4 bg-gradient-to-r from-pink-50 via-white to-cyan-50 shadow-md">
-      <div className="flex items-center justify-center w-full">
-        <div className="flex items-center w-1/4 justify-start">
+      <div className="flex items-center justify-between md:justify-center w-full">
+        {/* Logo */}
+        <div className="flex items-center md:w-1/4 justify-start">
           <Link to="/" className="flex items-center">
             <img src={logo} alt="vikash.app logo" style={{ height: 32, marginRight: '1rem' }} />
           </Link>
         </div>
-        <div className="flex items-center justify-center w-2/4">
+
+        {/* Desktop nav links */}
+        <div className="hidden md:flex items-center justify-center md:w-2/4">
           <div className="flex text-lg font-semibold" style={{ gap: '3rem' }}>
-            <Link to="/" className={pathname === "/" ? "text-pink-600 underline" : "text-gray-700 hover:text-pink-500 transition"}>Home</Link>
-            <Link to="/travel-destinations" className={pathname.startsWith("/travel-destinations") ? "text-pink-600 underline" : "text-gray-700 hover:text-pink-500 transition"}>Destinations</Link>
-            <Link to="/about" className={pathname === "/about" ? "text-pink-600 underline" : "text-gray-700 hover:text-pink-500 transition"}>About</Link>
+            <Link to="/" className={linkClass("/")}>Home</Link>
+            <Link to="/travel-destinations" className={linkClass("/travel-destinations")}>Destinations</Link>
+            <Link to="/about" className={linkClass("/about")}>About</Link>
           </div>
         </div>
-        <div className="w-1/4"></div>
+        <div className="hidden md:block md:w-1/4"></div>
+
+        {/* Hamburger button — mobile only */}
+        <button
+          className="md:hidden p-2 text-gray-700 hover:text-pink-500 transition"
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label={menuOpen ? "Close menu" : "Open menu"}
+        >
+          {menuOpen ? (
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          ) : (
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          )}
+        </button>
       </div>
+
+      {/* Mobile dropdown menu */}
+      {menuOpen && (
+        <div className="md:hidden mt-4 flex flex-col items-center gap-4 text-lg font-semibold pb-2">
+          <Link to="/" className={linkClass("/")} onClick={() => setMenuOpen(false)}>Home</Link>
+          <Link to="/travel-destinations" className={linkClass("/travel-destinations")} onClick={() => setMenuOpen(false)}>Destinations</Link>
+          <Link to="/about" className={linkClass("/about")} onClick={() => setMenuOpen(false)}>About</Link>
+        </div>
+      )}
     </nav>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import "tailwindcss";
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -24,12 +26,9 @@ a:hover {
 
 body {
   margin: 0;
-  min-width: 320px; /* Ensures minimum width for mobile devices */
-  min-height: 100vh; /* Ensures minimum height for mobile devices */
-  {/* display: flex;
-  place-items: center;*/}
-  min-width: 100vw;
+  min-width: 320px;
   min-height: 100vh;
+  min-width: 100vw;
 }
 
 h1 {
@@ -68,9 +67,6 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
 
 /* Custom styles for light/dark theme switching */
 body {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -30,7 +30,7 @@ export default function Home() {
       </section>
       <section className="w-full">
         <h2 className="text-3xl font-bold mb-6 text-pink-600 text-center">Featured Destinations</h2>
-        <div className="grid grid-cols-4 gap-y-8 w-full" style={{textAlign: 'initial'}}>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 w-full" style={{textAlign: 'initial'}}>
           {featured.map(dest => (
             <DestinationCard key={dest.id} dest={dest} />
           ))}


### PR DESCRIPTION
## Summary
- Make the Featured Destinations grid responsive: 1 column on mobile, 2 on tablet, 4 on desktop
- Add a mobile hamburger menu to the Navbar with toggle open/close, replacing the rigid 3-column layout that overflowed on small screens
- Fix Tailwind v4 CSS: replace deprecated `@tailwind` directives with `@import "tailwindcss"` so responsive utilities are generated correctly
- Desktop layout remains unchanged

## Test plan
- [ ] Open the site at ~375px width — grid shows 1 column, hamburger icon visible, nav links in dropdown
- [ ] Open at ~768px — grid shows 2 columns, desktop nav appears
- [ ] Open at ~1200px — grid shows 4 columns, full navbar as before
- [ ] Click hamburger to open/close mobile menu
- [ ] Click a nav link in mobile menu — menu closes and navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)